### PR TITLE
implemented monkeypatching requests + fly.io ollama service

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "main": "index.js",
   "scripts": {
     "deploy:serp": "cd services/serpapi ; fly deploy",
-    "deploy:imageapi": "fly deploy -c ./services/imageapiFlask/fly.toml --local-only -e HUGGING_FACE_API_TOKEN=$(dotenv -f .env get HUGGING_FACE_API_TOKEN) -e ADMIN_API_KEY=$(dotenv -f .env get ADMIN_API_KEY)"
+    "deploy:imageapi": "fly deploy -c ./services/imageapiFlask/fly.toml --local-only -e HUGGING_FACE_API_TOKEN=$(dotenv -f .env get HUGGING_FACE_API_TOKEN) -e ADMIN_API_KEY=$(dotenv -f .env get ADMIN_API_KEY)",
+    "deploy:ollama": "fly deploy -c ./services/ollama/fly.toml --local-only"
   },
   "keywords": [],
   "author": "",

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,9 @@ free-proxy
 pydantic
 craiyon.py
 pillow
+dnspython
+docker
+colorama
+yaspin
+cronitor
+pyngrok

--- a/services/imageapiFlask/fly.toml
+++ b/services/imageapiFlask/fly.toml
@@ -9,15 +9,15 @@ primary_region = 'jnb'
 [build]
   dockerfile = 'Dockerfile'
 
-[http_service]
-  internal_port = 5000
-  force_https = true
-  auto_stop_machines = 'stop'
-  auto_start_machines = true
-  min_machines_running = 0
-  processes = ['app']
-
 [[vm]]
   memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
+
+[[services]]
+  protocol = "tcp"
+  internal_port = 5000 
+
+[[services.ports]]
+  handlers = ["http"]
+  port = "5000"

--- a/services/ollama/fly.toml
+++ b/services/ollama/fly.toml
@@ -1,0 +1,29 @@
+# fly.toml app configuration file generated for ollama-api-kentucky-1948 on 2024-08-05T10:03:56+02:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = 'ollama-api-kentucky-1948'
+primary_region = 'ord'
+
+[build]
+  image = 'ollama/ollama'
+
+[[mounts]]
+  source = 'models'
+  destination = '/root/.ollama'
+  initial_size = '100gb'
+
+[[services]]
+  protocol = 'tcp'
+  internal_port = 11434
+
+[[services.ports]]
+  port = 11434
+  handlers = ['http']
+
+[[vm]]
+  size = 'a100-40gb'
+  memory = '32gb'
+  cpu_kind = 'performance'
+  cpus = 8

--- a/src/__init__.py
+++ b/src/__init__.py
@@ -1,0 +1,5 @@
+from .init.monkeypatch import MonkeypatchInternalRequests
+
+MonkeypatchInternalRequests.patch_requests()
+
+print("Requests Patched")

--- a/src/init/monkeypatch.py
+++ b/src/init/monkeypatch.py
@@ -1,0 +1,123 @@
+import time
+from urllib.parse import urlparse, urlunparse
+
+import dns.resolver
+import requests
+
+
+class MonkeypatchInternalRequests:
+    cached_records = []
+    last_cache_update = 0
+    cache_duration = 180
+
+    @staticmethod
+    def _update_cache():
+        """Updates the cache if it isn't valid anymore."""
+        current_time = time.time()
+        if (
+            current_time - MonkeypatchInternalRequests.last_cache_update
+        ) > MonkeypatchInternalRequests.cache_duration:
+            MonkeypatchInternalRequests.cached_records = (
+                MonkeypatchInternalRequests._fetch_dns_records()
+            )
+            MonkeypatchInternalRequests.last_cache_update = current_time
+
+    @staticmethod
+    def _fetch_dns_records():
+        """Fetch and return a list of internal aliases."""
+        internal_aliases = MonkeypatchInternalRequests.get_txt_records("_apps.internal")
+        if internal_aliases:
+            aliases = internal_aliases[0].split(",")
+            print(f"Internal Aliases: {aliases}")
+            return aliases
+        return []
+
+    @staticmethod
+    def get_txt_records(domain):
+        """Fetch TXT records from DNS."""
+        try:
+            answers = dns.resolver.resolve(domain, "TXT")
+            txt_records = [txt_string.decode("utf-8") for rdata in answers for txt_string in rdata.strings]  # type: ignore
+            return txt_records
+        except Exception as e:
+            print(f"Error retrieving TXT records for {domain}: {e}")
+            return []
+
+    @staticmethod
+    def _make_request(method, url, *args, **kwargs):
+        """Handle request, expanding internal URLs if the URL uses the .internal TLD."""
+        MonkeypatchInternalRequests._update_cache()
+        original_url = url
+
+        parsed_url = urlparse(url)
+        port = (
+            "80" if ":" not in parsed_url.netloc else parsed_url.netloc.split(":")[-1]
+        )
+
+        if parsed_url.netloc.replace(":" + port, "").strip().endswith(".internal"):
+            base_domain = (
+                parsed_url.netloc.replace(":" + port, "").strip().split(".")[0]
+            )
+
+            matching_alias = min(
+                (
+                    alias
+                    for alias in MonkeypatchInternalRequests.cached_records
+                    if alias.startswith(base_domain)
+                ),
+                key=len,
+                default=None,
+            )
+
+            if matching_alias:
+                new_netloc = f"{matching_alias}.flycast:{port}"
+                parsed_url = parsed_url._replace(netloc=new_netloc)
+                url = urlunparse(parsed_url)
+
+                print(f"Modified URL: {url} (Original: {original_url})")
+
+        return method(url, *args, **kwargs)
+
+    @staticmethod
+    def patched_get(url, *args, **kwargs):
+        return MonkeypatchInternalRequests._make_request(
+            original_get, url, *args, **kwargs
+        )
+
+    @staticmethod
+    def patched_post(url, *args, **kwargs):
+        return MonkeypatchInternalRequests._make_request(
+            original_post, url, *args, **kwargs
+        )
+
+    @staticmethod
+    def patched_put(url, *args, **kwargs):
+        return MonkeypatchInternalRequests._make_request(
+            original_put, url, *args, **kwargs
+        )
+
+    @staticmethod
+    def patched_delete(url, *args, **kwargs):
+        return MonkeypatchInternalRequests._make_request(
+            original_delete, url, *args, **kwargs
+        )
+
+    @staticmethod
+    def patch_requests():
+        """Patch both requests module and requests.Session."""
+        global original_get, original_post, original_put, original_delete
+
+        original_get = requests.get
+        original_post = requests.post
+        original_put = requests.put
+        original_delete = requests.delete
+
+        requests.get = MonkeypatchInternalRequests.patched_get
+        requests.post = MonkeypatchInternalRequests.patched_post
+        requests.put = MonkeypatchInternalRequests.patched_put
+        requests.delete = MonkeypatchInternalRequests.patched_delete
+
+        requests.Session.get = MonkeypatchInternalRequests.patched_get  # type: ignore
+        requests.Session.post = MonkeypatchInternalRequests.patched_post  # type: ignore
+        requests.Session.put = MonkeypatchInternalRequests.patched_put  # type: ignore
+        requests.Session.delete = MonkeypatchInternalRequests.patched_delete  # type: ignore

--- a/test.py
+++ b/test.py
@@ -1,0 +1,5 @@
+import requests
+
+import src
+
+print(requests.get("http://imageapi.internal:5000").text)

--- a/test.py
+++ b/test.py
@@ -1,5 +1,0 @@
-import requests
-
-import src
-
-print(requests.get("http://imageapi.internal:5000").text)


### PR DESCRIPTION
## Context:

Our requesting to internal fly.io services are a bit custom due to the fact of us leveraging internal services. Due to the constraints that fly.io apps require to have globally unique names (even if the app isn't in the same organization, or is just private) is a limiting factor not allowing us to hard-code urls.

Hence I cam e up with an aliasing system to allow us to query fly.io machines via their alias.

## Changes:

- Implemented Request MonkeyPatching to allow for alias unbinding Ex: "http://ollama.internal:11434" -> "http://http://ollama-api-kentucky-1948.flycast:11434"
- Implemented ollama service to test the functionality of our api.

## Test plan:

Testing can be done quite simply, but requires a bit of setup work on the testers side, such as creating a wireguard conneciton.

## Steps:
0. Ensure a service is running that has a private network 
```bash
cd /Automa/Project/Root
npm run deploy:imageapi
```
1. Follow this GUIDE to setup a wireguard connection: [wireguard fly](https://fly.io/docs/blueprints/connect-private-network-wireguard/)
2. Run this python script:
```bash
python -c "import requests; import src; print(requests.get('http://imageapi.internal:5000').text)"
```

## Results:
You should expect an output like this:
```bash
python -c "import requests; import src; print(requests.get('http://imageapi.internal:5000').text)"
```

```html
Requests Patched
Internal Aliases: ['flyctl-interactive-shells-rvlzqkpyjpl7ytyd6ne82l5gq8tgxoa9b-539301', 'imageapi-smokey-tundra-9984', 'ollama-api-kentucky-1948', 'scrapeopsproxyapi-shy-breeze-5598', 'serpapi-shy-breeze-5598']
Modified URL: http://imageapi-smokey-tundra-9984.flycast:5000 (Original: http://imageapi.internal:5000)
<!doctype html>
<html lang=en>
<title>401 Unauthorized</title>
<h1>Unauthorized</h1>
<p>Invalid API Key</p>
```
